### PR TITLE
Make server return conversation data on friend request accept

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -395,7 +395,7 @@ async def accept_friend_request_v2(request: Request, background_tasks: Backgroun
     if not user_online:
         background_tasks.add_task(send_push_notification, username, f"{username} accepted your friend request", {}, request_sender)
 
-    return "Request Accepted!"
+    return {"name": request_sender, "conversation_id": conversation_id, "sender_presence": user_online}
 
 @app.get('/deny_friend_request/{username}/{token}/{deny_user}')
 async def deny_friend(username, token, deny_user):


### PR DESCRIPTION
## Description
Made Ringer Server return conversation data upon accepting a friend request.

## Related Issue
#132 

## Proposed Changes
When a friend request is accepted, Ringer Server now returns the name of the conversation, the conversation id, and whether the request sender is online.

## Checklist
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if necessary).
- [x] I have reviewed the code for any potential issues.