### PR TITLE
Fix websocket send error

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -94,7 +94,13 @@ class live_ws_handler:
             # Parse through active connections to check if online
             for connection in self.active_connections:
                 if connection['user'] == user and connection['websocket'] not in sent_conns:
-                    await connection['websocket'].send_json(message)
+                    # Try to send message to user
+                    # If fails, disconnect user
+                    try:
+                        await connection['websocket'].send_json(message)
+                    except:
+                        # Remove user from sockets list
+                        self.disconnect_user(connection['websocket'])
 
                     # Add websocket to sent connections to avoid duplicate sending
                     sent_conns.append(connection['websocket'])


### PR DESCRIPTION
## Description
Fixed an error with the websocket connections.
```py
Unexpected ASGI message 'websocket.send', after sending 'websocket.close'.
```

## Related Issue
#117 

## Proposed Changes
A `try` block was added to the websoccket send funtion in the "send_message" funtion inside the websocket handler.

## Checklist
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if necessary).
- [x] I have reviewed the code for any potential issues.